### PR TITLE
Fix metadata in sortkey (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2022-10-12
+
+### Fixed
+- If you wanted to use updatedAt, updatedBy, createdAt or createdBy in the gsiSk1 they were being left out. With this fix it's possible to use these attributes inside the gsiSk1 as well.
+
 ## [1.1.1] - 2022-10-12
 
 ### Added

--- a/examples/payment/functions/get.ts
+++ b/examples/payment/functions/get.ts
@@ -37,7 +37,7 @@ async function get() {
   }
 }
 
-getWithVersions().then(res => {
+get().then(res => {
   console.log("🚀 ~ file: get.js ~ line 15 ~ get ~ res", res);
 }).catch(err => {
   console.error("🚀 ~ file: get.js ~ line 17 ~ get ~ err", err);

--- a/examples/payment/testEvents/update.json
+++ b/examples/payment/testEvents/update.json
@@ -1,5 +1,4 @@
 {
-  "status": "open",
-  "orderId": "order_01GED091GHEWQM4CV9NEYMJ7WN",
-  "productId": "product_01GECZJH68H1DG0CG7WCGZ2818"
+  "status": "paid",
+  "paymentId": "payment_01GEJE9E4M53P559K3R5FTX9E4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@levarne/pineapple-engine",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@levarne/pineapple-engine",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.178.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@levarne/pineapple-engine",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Fruitful Serverless Pineapples will rule the world 1 day",
   "main": "dist/pineapple.js",
   "exports": {


### PR DESCRIPTION
* If you wanted to use updatedAt, updatedBy, createdAt or createdBy in the gsiSk1 they were being left out. With this fix it's possible to use these attributes inside the gsiSk1 as well.

* 1.1.2